### PR TITLE
Corrección de sintaxis en sections y subsections

### DIFF
--- a/practicos/Diseño_Desarrollo_e_Implementación/main.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/main.tex
@@ -287,7 +287,7 @@ En esta fase comenzaremos definiendo el Sprint backlog y describiendo en detalle
 \end{comment}
 
 
-\subsection{ Modelo de datos.}
+\subsection{Modelo de datos}
 El Diagrama propio de este sprint se puede ver en la \textbf{Figura\ref{2-modelo_datos_general}}, allí se indican exactamente las clases que se usarán en este sprint y que serán detalladas con detenimiento en el presente documento. Se recuerda que se ha realizado un Diagrama de clases tentativo que se puede ver en la \textbf{Figura \ref{2-modelo_datos_general}}, dicho diagrama  será utilizado como base para este sprint y posee un alcance limitado el cual se irá modificando a medida que se profundice en los temas.
 
 
@@ -445,7 +445,7 @@ Esta clase nos permitirá nomenclar los tipos de fuentes posibles como pueden se
 }
     \end{lstlisting}
     
-\subsection{ Modelo funcional.} %Diagrama de clases
+\subsection{Modelo funcional} %Diagrama de clases
 Se describirán las funciones usando como marco de apoyo el sprint Backlog, además se armará el diagrama de casos de uso del presente Sprint \textbf{[Figura \ref{2-caso_de_uso}]} que irá creciendo  medida se vaya avanzando en el proyecto.
     \begin{figure}[h]
         \centering
@@ -1028,7 +1028,7 @@ Aqui se realizará una conclusión general de lo que se descubrió en las prueba
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%      FIN SPRINT 2  %%%%%%%%%%%%%%%%%%%%%%%%%
 
-\section{Sprint 3: }%Corrección de issues 
+\section{Sprint 3}%Corrección de issues 
 \subsection{Planificación}
 
 \textbf{Inicio: }Martes 7 de julio del 2015 
@@ -1375,7 +1375,7 @@ angular.module('saludWebApp')
        
 	\end{itemize}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%      FIN SPRINT 3  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Sprint 4: }%mostrar gráficas -validaciones
+\section{Sprint 4}%mostrar gráficas -validaciones
 \subsection{Planificación}
 
 \textbf{Inicio: }Martes 17 de julio del 2015 
@@ -1467,7 +1467,7 @@ La \textbf{Tabla \ref{US-Sprint3} } indicará las características de cada user 
 
 \end{table}
 
-\subsection{ Modelo funcional.} 
+\subsection{Modelo funcional} 
 Se describirán las funciones usando como marco de apoyo el sprint Backlog,
 además se armará el diagrama de casos de uso del presente Sprint [Figura 44] que
 irá creciendo medida se vaya avanzando en el proyecto.
@@ -1666,7 +1666,7 @@ El Diagrama propio de este sprint se puede ver en la \textbf{Figura\ref{5-clase_
 		\label{5-clase_autenticacion}
     \end{figure}
 
-\subsection{ Modelo funcional.} 
+\subsection{Modelo funcional} 
 Se define el diagrama de casos de uso del presente Sprint \textbf{[Figura \ref{4-cu_autenticacion}]}.
 
     \begin{figure}[h]
@@ -1825,11 +1825,11 @@ curl -u akathy:kathy1234 http://localhost:5000/token
 
 \subsection{Casos de prueba}
 
-\subsubsection{Pruebas  de  integración  entre módulos del Sistema}
+\subsubsection{Pruebas de integración entre módulos del Sistema}
 
-\subsubsection{ Pruebas de carga}
+\subsubsection{Pruebas de carga}
 
-\subsubsection{ Pruebas de seguridad por niveles de usuarios}
+\subsubsection{Pruebas de seguridad por niveles de usuarios}
 
 
 \subsection{Pruebas ejecutadas}
@@ -1953,7 +1953,7 @@ La tabla \ref{sprint_backlog_6} indica las características de cada user story p
     \label{sprint_backlog_6}
 \end{table}
 
-\subsection{ Modelo funcional.} %Diagrama de clases
+\subsection{Modelo funcional} %Diagrama de clases
 Se describirán las funciones usando como marco de apoyo el sprint Backlog, además se armará el diagrama de casos de uso del presente Sprint \textbf{[Figura \ref{6-cu}]} acompañado de los casos de uso que se obtuvieron como resultado de los sprint anteriores
 
 
@@ -2605,7 +2605,7 @@ Selecciona \textit{\textbf{Mi cuenta}}, luego \textit{\textbf{Cerrar Sesiónn}}
 
 
 
-\subsubsection{ Pruebas de carga}
+\subsubsection{Pruebas de carga}
 Se va a simular el acceso a la página hosteada en heroku, de un lote de usuarios. Además en la gráfica \textbf{[Figura \ref{prueba_carga_50_us}]}se puede ver los tiempos de respuesta al ir incrementando la cantidad de usuarios.
 
 \begin{center}
@@ -2676,7 +2676,7 @@ en nuestro caso nos recomienda disminuir el tamaño de las imágenes \textbf{[Fi
 	\label{pc_a_2}
 \end{figure}
 
-\subsubsection{ Pruebas de seguridad por niveles de usuarios}
+\subsubsection{Pruebas de seguridad por niveles de usuarios}
 
 \begin{longtable}{|p{1.0cm}|p{4cm}|p{4cm}|p{4cm}| }
 
@@ -2781,7 +2781,7 @@ El Diagrama propio de este sprint se puede ver en la \textbf{Figura\ref{6-clases
 		\label{6-clases_file_upload}
     \end{figure}
 
-\subsection{ Modelo funcional.} %Diagrama de clases
+\subsection{Modelo funcional} %Diagrama de clases
 Se describirán las funciones usando como marco de apoyo el sprint Backlog, además se armará el diagrama de casos de uso del presente Sprint \textbf{[Figura \ref{6-cu_file_upload}]} que irá creciendo  medida se vaya avanzando en el proyecto.
 
     \begin{figure}[h]
@@ -2999,9 +2999,9 @@ Date: Tue, 20 Oct 2015 19:10:33 GMT
 
 \subsubsection{Pruebas  de  integración  entre módulos del Sistema}
 
-\subsubsection{ Pruebas de carga}
+\subsubsection{Pruebas de carga}
 
-\subsubsection{ Pruebas de seguridad por niveles de usuarios}
+\subsubsection{Pruebas de seguridad por niveles de usuarios}
 
 
 \subsection{Pruebas ejecutadas}
@@ -3065,7 +3065,7 @@ El Diagrama propio de este sprint se puede ver en la \textbf{Figura\ref{2-modelo
 %\textbf{AÑADIR DIAGRAMA DE CLASEEES}
 
 
-\subsection{ Modelo funcional.} %Diagrama de clases
+\subsection{Modelo funcional} %Diagrama de clases
 Se describirán las funciones usando como marco de apoyo el sprint Backlog, además se armará el diagrama de casos de uso del presente Sprint \textbf{[Figura \ref{2-caso_de_uso}]} que irá creciendo  medida se vaya avanzando en el proyecto.
 
 
@@ -3142,11 +3142,11 @@ Se describirán las funciones usando como marco de apoyo el sprint Backlog, adem
 
 \subsection{Casos de prueba}
 
-\subsubsection{Pruebas  de  integración  entre módulos del Sistema}
+\subsubsection{Pruebas de integración  entre módulos del Sistema}
 
-\subsubsection{ Pruebas de carga}
+\subsubsection{Pruebas de carga}
 
-\subsubsection{ Pruebas de seguridad por niveles de usuarios}
+\subsubsection{Pruebas de seguridad por niveles de usuarios}
 
 
 \subsection{Pruebas ejecutadas}
@@ -3212,7 +3212,7 @@ El Diagrama propio de este sprint se puede ver en la \textbf{Figura\ref{2-modelo
 \textbf{AÑADIR DIAGRAMA DE CALSEEES}
 
 
-\subsection{ Modelo funcional.} %Diagrama de clases
+\subsection{Modelo funcional} %Diagrama de clases
 Se describirán las funciones usando como marco de apoyo el sprint Backlog, además se armará el diagrama de casos de uso del presente Sprint \textbf{[Figura \ref{2-caso_de_uso}]} que irá creciendo  medida se vaya avanzando en el proyecto.
 
 
@@ -3284,11 +3284,11 @@ Se describirán las funciones usando como marco de apoyo el sprint Backlog, adem
 
 \subsection{Casos de prueba}
 
-\subsubsection{Pruebas  de  integración  entre módulos del Sistema}
+\subsubsection{Pruebas de integración entre módulos del Sistema}
 
-\subsubsection{ Pruebas de carga}
+\subsubsection{Pruebas de carga}
 
-\subsubsection{ Pruebas de seguridad por niveles de usuarios}
+\subsubsection{Pruebas de seguridad por niveles de usuarios}
 
 
 \subsection{Pruebas ejecutadas}
@@ -3651,8 +3651,8 @@ El objetivo de este documento consiste en describir técnicamente el diseño de 
 \subsection{Técnicas de programación utilizadas}
 \subsection{Entorno, herramientas y tecnologías utilizadas}
 %LO HICIMOS EN OTRO LADO!!!!!!
-\subsection{código fuente}
-\subsection{pruebas}
+\subsection{Código fuente}
+\subsection{Pruebas}
 
 
 
@@ -3818,7 +3818,7 @@ las capacitaciones, casos referentes a circunstancias que posiblemente se presen
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Ejecución, documentación y retroalimentación de pruebas.}
+\section{Ejecución, documentación y retroalimentación de pruebas}
 %Sólo se debe registrar en el mismo formulario o documento del plan de pruebas de la etapa anterior. Se deben registrar los resultados obtenidos por la ejecución de las pruebas planificadas y las acciones correctivas realizadas, si hubieren correspondido (tengan en cuenta lo aportado por el Ing. Diego Villa).
  La retroalimentación de las pruebas referidas a la función de carga y muestra de análisis, se detallan al finalizar los sprint que se describen a continuación acompañados de una breve descripción de las actividades realizadas.
  \begin{itemize}


### PR DESCRIPTION
Se eliminan espacios y puntuación que no debe estar presente en los ```section``` y ```subsection```.