### PR TITLE
Corrección de referencias a tablas de User Stories

### DIFF
--- a/practicos/Diseño_Desarrollo_e_Implementación/main.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/main.tex
@@ -365,7 +365,7 @@ Para cada una de esas clases, se deben preparar interfaces de acceso a los recur
 
 
 \subsection{User Stories relacionados}
-La \textbf{Tabla \ref{US-Sprint1}} indicará las características de cada user story para guiarnos en el desarrollo del sprint.
+La \textbf{Tabla \ref{US-Sprint2}} indicará las características de cada user story para guiarnos en el desarrollo del sprint.
 
 \begin{table}[h]
 	%\resizebox{\textwidth}{!}{
@@ -386,7 +386,7 @@ La \textbf{Tabla \ref{US-Sprint1}} indicará las características de cada user s
     \hline
     \end{tabular}
 %     }
-    \label{US-Sprint1}
+    \label{US-Sprint2}
 \end{table}
 
 
@@ -1541,10 +1541,10 @@ angular.module('saludWebApp')
 Además se describirán las tareas realizadas para realizar las gráficas de las distintas mediciones
 
 \subsection{User Stories relacionados}
-La \textbf{Tabla \ref{US-Sprint3} } indicará las características de cada user story para guiarnos en el desarrollo del sprint.
+La \textbf{Tabla \ref{US-Sprint4} } indicará las características de cada user story para guiarnos en el desarrollo del sprint.
 
 \begin{table}[h]
-    \label{US-Sprint3}
+    \label{US-Sprint4}
 	%\resizebox{\textwidth}{!}{
     \centering
 	\begin{tabular}{|l|p{14cm}|}
@@ -2043,7 +2043,7 @@ Aqui se realizará una conclusión general de lo que se descubrió en las prueba
 	 
 
 \subsection{User Stories relacionados}
-La tabla \ref{sprint_backlog_6} indica las características de cada user story para guiarnos en el desarrollo del sprint.
+La \textbf{Tabla \ref{US-Sprint6}} indica las características de cada user story para guiarnos en el desarrollo del sprint.
 
 \begin{table}[h]
 
@@ -2060,7 +2060,7 @@ La tabla \ref{sprint_backlog_6} indica las características de cada user story p
     \hline
     \end{tabular}
 %     }
-    \label{sprint_backlog_6}
+    \label{US-Sprint6}
 \end{table}
 
 \subsection{ Modelo funcional.} %Diagrama de clases
@@ -2857,10 +2857,10 @@ en nuestro caso nos recomienda disminuir el tamaño de las imágenes \textbf{[Fi
 En este sprint se busca brindarle al usuario la funcionalidad para poder cargar imágenes, así este puede dejar un respaldo digital de lo que puede ser un análisis clínico o una imágen de radiografía y demás documentos médicos físicos. Para el mismo se plantean dos variantes, una local y otra en un servicio de almacenamiento, debido a que el desarrollo de ambas presentan sus diferencias y a su ves existen diferentes servicios de almacenamiento, se debe prever una estructura que soporte el impacto frente al cambio.
 
 \subsection{User Stories relacionados}
-La \textbf{Tabla \ref{US-Sprint6} } indicará las características de cada user story para guiarnos en el desarrollo del sprint.
+La \textbf{Tabla \ref{US-Sprint7} } indicará las características de cada user story para guiarnos en el desarrollo del sprint.
 % No entiendo porque para la tabla renderiza con ?? en el pdf.
 \begin{table}[h]
-    \label{US-Sprint6}
+    \label{US-Sprint7}
 	%\resizebox{\textwidth}{!}{
     \centering
 	\begin{tabular}{|l|p{9cm}|}
@@ -3150,10 +3150,10 @@ Aqui se realizará una conclusión general de lo que se descubrió en las prueba
 \subsection{Descripción}
 
 \subsection{User Stories relacionados}
-La \textbf{Tabla \ref{US-Sprint3} } indicará las características de cada user story para guiarnos en el desarrollo del sprint.
+La \textbf{Tabla \ref{US-Sprint8}} indicará las características de cada user story para guiarnos en el desarrollo del sprint.
 %\textbf{ESTO ES UN EJEMPLOOOO HAY QUE INDICAR TDOS LOS US RELACIONADO}
 \begin{table}[h]
-    \label{US-Sprint3}
+    \label{US-Sprint8}
 	%\resizebox{\textwidth}{!}{
     \centering
 	\begin{tabular}{|l|p{9cm}|}
@@ -3296,10 +3296,10 @@ Aqui se realizará una conclusión general de lo que se descubrió en las prueba
 \subsection{Descripción}
 
 \subsection{User Stories relacionados}
-La \textbf{Tabla \ref{US-Sprint3} } indicará las características de cada user story para guiarnos en el desarrollo del sprint.
+La \textbf{Tabla \ref{US-Sprint9}} indicará las características de cada user story para guiarnos en el desarrollo del sprint.
 \textbf{ESTO ES UN EJEMPLOOOO HAY QUE INDICAR TDOS LOS US RELACIONADO}
 \begin{table}[h]
-    \label{US-Sprint3}
+    \label{US-Sprint9}
 	%\resizebox{\textwidth}{!}{
     \centering
 	\begin{tabular}{|l|p{9cm}|}


### PR DESCRIPTION
Las definiciones de *labels* para tablas de User Stories se repetían, y sus referencias eran incorrectas. Se solucionó renombrando los *labels* y *refs* incorrectos.