### PR TITLE
Integración de bibliografía y corrección de formato

### DIFF
--- a/practicos/Diseño_Desarrollo_e_Implementación/biblio.bib
+++ b/practicos/Diseño_Desarrollo_e_Implementación/biblio.bib
@@ -1,354 +1,504 @@
-@misc{ wiki:xxx,
-       author = "Wikipedia",
-       title = "Front-end y back-end --- Wikipedia{,} La enciclopedia libre",
-       year = "2015",
-       url = "http://es.wikipedia.org/w/index.php?title=Front-end_y_back-end&oldid=82186853",
-       note = "[Internet; descargado 2-junio-2015]"
+% Trabajo práctico 1 - Parte 2
+
+@misc{
+    wiki:frontend_backend,
+    author = "Wikipedia",
+    title = "Front-end y back-end --- Wikipedia{,} La enciclopedia libre",
+    year = "2015",
+    url = "http://es.wikipedia.org/w/index.php?title=Front-end_y_back-end&oldid=82186853",
+    note = "[Internet; descargado 2-junio-2015]"
 }
 
-@misc{ ang:xxx,
-	   author = "Angular",
-       title = "AngularJS ",
-       url = "https://angularjs.org/"
-      
+@misc{
+    ang:sitio_oficial,
+    author = "AngularJS",
+    title = "Sitio oficial de AngularJS",
+    year = "2015",
+    url = "https://angularjs.org/"
 }
 
-@misc{ wiki:xxx,
-       author = "Wikipedia",
-       title = "DevOps --- Wikipedia{,} La enciclopedia libre",
-       year = "2015",
-       url = "http://es.wikipedia.org/w/index.php?title=DevOps&oldid=82549358",
-       note = "[Internet; descargado 2-junio-2015]"
+@misc{
+    wiki:devops,
+    author = "Wikipedia",
+    title = "DevOps --- Wikipedia{,} La enciclopedia libre",
+    year = "2015",
+    url = "http://es.wikipedia.org/w/index.php?title=DevOps&oldid=82549358",
+    note = "[Internet; descargado 2-junio-2015]"
 }
 
-@misc{ wiki:xxx,
-   author = "Wikipedia",
-   title = "Shippable --- Wikipedia{,} The Free Encyclopedia",
-   year = "2014",
-   url = "http://en.wikipedia.org/w/index.php?title=Shippable&oldid=637226960",
-   note = "[Online; accessed 2-June-2015]"
+@misc{
+    wiki:shippable,
+    author = "Wikipedia",
+    title = "Shippable --- Wikipedia{,} The Free Encyclopedia",
+    year = "2014",
+    url = "http://en.wikipedia.org/w/index.php?title=Shippable&oldid=637226960",
+    note = "[Online; accessed 2-June-2015]"
  }
  
- @misc{kar:xxx, 
-       author = "Karma",
-       title = "Karma ",
-       url = "http://karma-runner.github.io/0.12/index.html"
-      
+@misc{
+    kar:sitio_oficial,
+    author = "Karma",
+    title = "Sitio oficial de Karma",
+    year = "2015",
+    url = "http://karma-runner.github.io/"
 }
 
- @misc{jas:xxx, 
-       author = "Jasmin",
-       title = "Jasmin-Introduccion ",
-       url = "http://jasmine.github.io/edge/introduction.html"
-      
+@misc{
+    jas:intro,
+    author = "Jasmine",
+    title = "Introducción a Jasmine",
+    url = "http://jasmine.github.io/edge/introduction.html"
 }
 
- @misc{jav:xxx, 
-       author = "Javier Garzás",
-       title = "Sprint 0",
-       url = "http://www.javiergarzas.com/2013/07/el-sprint-cero-y-el-sprint-de-release.html"
-      
-}
-%Trabajo práctico 1 parte 1
-@misc{ wiki:xxx,
-	author = "Wikipedia",
-	title = "Carpeta de Salud --- Wikipedia{,} La enciclopedia libre",
-	year = "2015",
-	url = "http://es.wikipedia.org/w/index.php?title=Carpeta_de_Salud&oldid=82184105",
-	note = "{Internet; descargado 9-mayo-2015}"
+@misc{
+    garzas:sprint_cero,
+    author = "Garzás, Javier",
+    title = " El Sprint cero y el Sprint de release",
+    year = "2013",
+    url = "http://www.javiergarzas.com/2013/07/el-sprint-cero-y-el-sprint-de-release.html"
 }
 
-@misc{ healthvault,
-	author = "Microsoft",
-	title = "HealthVault",
-	year = "2015",
-	url = "https://www.healthvault.com/ar/es",
-	note = "{Internet; descargado 9-mayo-2015}"
-}
-@misc{ hospitalitaliano,
-	author = "Hospital Italiano de Bs As",
-	title = "Historia Clínica Electrónica",
-	year = "2007",
-	url = "https://www.hospitalitaliano.org.ar",
-}
-@misc{ openhealth,
-	author = "Open Health",
-	title = "Plataforma libre para el desarrollo de sistemas de salud",
-	year = "2015",
-	url = "http://www.openehr.org/",
-}
-@misc{ wiki:xxxy,
-	author = "Wikipedia",
-	title = "Historia médica",
-	year = "2015",
-	url = "https://en.wikipedia.org/wiki/Medical_history",
-}
-@misc{ wiki:xxxz,
-	author = "Wikipedia",
-	title = "Registro de salud electrónico",
-	year = "2015",
-	url = "https://en.wikipedia.org/wiki/Electronic_health_record",
-}
-@misc{ ley,
-	author = "Ministerio de Salud",
-	title = "Ley 26.529 (Texto reducido) - Derechos del Paciente en su relación con los Profesionales e Instituciones de la salud",
-	year = "2009",
-	url = "http://www.ms.gba.gov.ar/sitios/srpr/files/2014/09/Derecho-paciente-profesion.pdf",
-}
-@misc{ ley,
-	author = "PMO",
-	title = "Roles y Reuniones en la Metodología Scrum",
-	year = "2010",
-	url = "http://spanishpmo.com/index.php/roles-y-reuniones-en-la-metodologia-scrum/",
+% Trabajo práctico 1 - Parte 1
+
+@misc{
+    wiki:carpeta_salud,
+    author = "Wikipedia",
+    title = "Carpeta de Salud --- Wikipedia{,} La enciclopedia libre",
+    year = "2015",
+    url = "http://es.wikipedia.org/w/index.php?title=Carpeta_de_Salud&oldid=82184105",
+    note = "{Internet; descargado 9-mayo-2015}"
 }
 
-@misc{ HL7,
-	author = "HL7",
-	title = "Producto CCD --- HL7",
-	year = "2010",
-	url = "http://wiki.hl7.org/index.php?title=Product_CCD",
-	note = "{Internet; descargado 10-julio-2015}"
+@misc{
+    healthvault,
+    author = "Microsoft",
+    title = "HealthVault",
+    year = "2015",
+    url = "https://www.healthvault.com/ar/es",
+    note = "{Internet; descargado 9-mayo-2015}"
 }
 
-@misc{ wiki:xxxa,
-	author = "Wikipedia",
-	title = "HL7 v3",
-	year = "2015",
-	url = "https://es.wikipedia.org/wiki/HL7_v3",
+@misc{
+    hospitalitaliano,
+    author = "{Hospital Italiano de Buenos Aires}",
+    title = "Sitio oficial del Hospital Italiano de Buenos Aires",
+    year = "2015",
+    url = "https://www.hospitalitaliano.org.ar",
 }
 
-@misc{ wiki:xxxb,
-	author = "Wikipedia",
-	title = "CIE-10",
-	year = "2015",
-	url = "https://es.wikipedia.org/wiki/CIE-10",
+@misc{
+    openehr:sitio_oficial,
+    author = "OpenEHR",
+    title = "OpenEHR: Plataforma libre para el desarrollo de sistemas de salud",
+    year = "2015",
+    url = "http://www.openehr.org/",
 }
 
-@misc{ wiki:xxxc,
-	author = "Wikipedia",
-	title = "Snomed-CT",
-	year = "2015",
-	url = "https://es.wikipedia.org/wiki/Snomed-CT",
+@misc{
+    wiki:historia_medica,
+    author = "Wikipedia",
+    title = "Historia médica",
+    year = "2015",
+    url = "https://en.wikipedia.org/wiki/Medical_history",
 }
 
-@misc{ wiki:xxxd,
-	author = "Wikipedia",
-	title = "Código ATC",
-	year = "2015",
-	url = "https://es.wikipedia.org/wiki/C%C3%B3digo_ATC",
+@misc{
+    wiki:ehr,
+    author = "Wikipedia",
+    title = "Registro de salud electrónico",
+    year = "2015",
+    url = "https://en.wikipedia.org/wiki/Electronic_health_record",
 }
 
-@misc{ wiki:xxxe,
-	author = "Wikipedia",
-	title = "Clinical Document Arqhitecture",
-	year = "2015",
-	url = "https://en.wikipedia.org/wiki/Clinical_Document_Architecture",
+@misc{
+    minsalud:ley_26529,
+    author = "{Ministerio de Salud}",
+    title = "Ley 26.529 (Texto reducido) - Derechos del Paciente en su relación con los Profesionales e Instituciones de la salud",
+    year = "2009",
+    url = "http://www.ms.gba.gov.ar/sitios/srpr/files/2014/09/Derecho-paciente-profesion.pdf",
 }
 
-@misc{ wiki:xxxf,
-	author = "Wikipedia",
-	title = "Clasificación internacional de atención primaria",
-	year = "2015",
-	url = "https://es.wikipedia.org/wiki/Clasificaci%C3%B3n_Internacional_de_Atenci%C3%B3n_Primaria",
+@misc{
+    pmo:roles_reuniones_scrum,
+    author = "SpanishPMO",
+    title = "Roles y Reuniones en la Metodología Scrum",
+    year = "2010",
+    url = "http://spanishpmo.com/index.php/roles-y-reuniones-en-la-metodologia-scrum/",
 }
 
-@misc{ wiki:xxxg,
-	author = "Wikipedia",
-	title = "Computerized physician order entry",
-	year = "2015",
-	url = "https://en.wikipedia.org/wiki/Computerized_physician_order_entry",
+@misc{
+    hl7:ccd,
+    author = "HL7",
+    title = "Producto CCD --- HL7",
+    year = "2010",
+    url = "http://wiki.hl7.org/index.php?title=Product_CCD",
+    note = "{Internet; descargado 10-julio-2015}"
 }
 
-@misc{ wiki:xxxh,
-	author = "Wikipedia",
-	title = "Continuidad del Registro del Cuidado",
-	year = "2015",
-	url = "https://es.wikipedia.org/wiki/Continuidad_del_Registro_del_Cuidado",
+@misc{
+    wiki:hl7,
+    author = "Wikipedia",
+    title = "HL7 v3",
+    year = "2015",
+    url = "https://es.wikipedia.org/wiki/HL7_v3",
 }
 
-@misc{ OpenEHR,
-	author = "OpenEHR",
-	title = "Modelo de referencia para la interoperabilidad y computabilidad de e-health",
-	year = "2015",
-	url = "http://www.openehr.org/what_is_openehr",
-}
-%Trabajo práctico 1 parte 2
-@misc{ wiki:xxx,
-	author = "Wikipedia",
-	title = "Front-end y back-end --- Wikipedia{,} La enciclopedia libre",
-	year = "2015",
-	url = "http://es.wikipedia.org/w/index.php?title=Front-end_y_back-end&oldid=82186853",
-	note = "[Internet; descargado 2-junio-2015]"
+@misc{
+    wiki:cie_10,
+    author = "Wikipedia",
+    title = "CIE-10",
+    year = "2015",
+    url = "https://es.wikipedia.org/wiki/CIE-10",
 }
 
-@misc{ 
-	author = "Angular",
-	title = "AngularJS ",
-	url = "https://angularjs.org/"
-	
+@misc{
+    wiki:snomed,
+    author = "Wikipedia",
+    title = "Snomed-CT",
+    year = "2015",
+    url = "https://es.wikipedia.org/wiki/Snomed-CT",
 }
 
-@misc{ wiki:xxx,
-	author = "Wikipedia",
-	title = "DevOps --- Wikipedia{,} La enciclopedia libre",
-	year = "2015",
-	url = "http://es.wikipedia.org/w/index.php?title=DevOps&oldid=82549358",
-	note = "[Internet; descargado 2-junio-2015]"
+@misc{
+    wiki:codigo_atc,
+    author = "Wikipedia",
+    title = "Código ATC",
+    year = "2015",
+    url = "https://es.wikipedia.org/wiki/C%C3%B3digo_ATC",
 }
 
-@misc{ wiki:xxx,
-	author = "Wikipedia",
-	title = "Shippable --- Wikipedia{,} The Free Encyclopedia",
-	year = "2014",
-	url = "http://en.wikipedia.org/w/index.php?title=Shippable&oldid=637226960",
-	note = "[Online; accessed 2-June-2015]"
+@misc{
+    wiki:cda,
+    author = "Wikipedia",
+    title = "Clinical Document Arqhitecture",
+    year = "2015",
+    url = "https://en.wikipedia.org/wiki/Clinical_Document_Architecture",
 }
 
-@misc{ 
-	author = "Karma",
-	title = "Karma ",
-	url = "http://karma-runner.github.io/0.12/index.html"
-	
+@misc{
+    wiki:clasificacion_atencion_primaria,
+    author = "Wikipedia",
+    title = "Clasificación internacional de atención primaria",
+    year = "2015",
+    url = "https://es.wikipedia.org/wiki/Clasificaci%C3%B3n_Internacional_de_Atenci%C3%B3n_Primaria",
 }
 
-@misc{ 
-	author = "Jasmin",
-	title = "Jasmin-Introduccion ",
-	url = "http://jasmine.github.io/edge/introduction.html"
-	
+@misc{
+    wiki:computerized_physician_order_entry,
+    author = "Wikipedia",
+    title = "Computerized physician order entry",
+    year = "2015",
+    url = "https://en.wikipedia.org/wiki/Computerized_physician_order_entry",
 }
 
-@misc{ 
-	author = "Javier Garzás",
-	title = "Sprint 0",
-	url = "http://www.javiergarzas.com/2013/07/el-sprint-cero-y-el-sprint-de-release.html"
-	
+@misc{
+    wiki:continuidad_registro_cuidado,
+    author = "Wikipedia",
+    title = "Continuidad del Registro del Cuidado",
+    year = "2015",
+    url = "https://es.wikipedia.org/wiki/Continuidad_del_Registro_del_Cuidado",
 }
 
-%Trabajo práctico integrador nº1
-@misc{ wiki:gestor-proyecto,
-	author = "Wikipedia",
-	title = "Gestor de proyecto --- Wikipedia{,} La enciclopedia libre",
-	year = "2015",
-	url = "http://es.wikipedia.org/w/index.php?title=Gestor_de_proyecto&oldid=79759057",
-	note = "[Internet; descargado 16-mayo-2015]"
+@misc{
+    openehr,
+    author = "OpenEHR",
+    title = "Modelo de referencia para la interoperabilidad y computabilidad de e-health",
+    year = "2015",
+    url = "http://www.openehr.org/what_is_openehr",
 }
 
-@misc{ punto2:estilos-liderazgo,
-	author = "euroresidentes",
-	title = "Los 3 estilos de liderazgo más efectivos en las organizaciones" ,
-	year = "2013",
-	url = "http://liderazgo.euroresidentes.com"
+% Trabajo práctico integrador 1
+
+@misc{
+    wiki:gestor-proyecto,
+    author = "Wikipedia",
+    title = "Gestor de proyecto --- Wikipedia{,} La enciclopedia libre",
+    year = "2015",
+    url = "http://es.wikipedia.org/w/index.php?title=Gestor_de_proyecto&oldid=79759057",
+    note = "[Internet; descargado 16-mayo-2015]"
 }
 
-@misc{ wiki:liderazgo,
-	author = "Wikipedia",
-	title = "Liderazgo",
-	year = "2015",
-	url = "http://es.wikipedia.org/wiki/Liderazgo"
-}
-@misc{ wiki:xxx,
-	author = "Wikipedia",
-	title = "Guía del usuario --- Wikipedia{,} La enciclopedia libre",
-	year = "2015",
-	url = "http://es.wikipedia.org/w/index.php?title=Gu%C3%ADa_del_usuario&oldid=79381229",
-	note = "[Internet; descargado 27-mayo-2015]"
+@misc{
+    punto2:estilos-liderazgo,
+    author = "Mendez Molla, Andrea",
+    title = "Los 3 estilos de liderazgo más efectivos en las organizaciones" ,
+    year = "2013",
+    url = "http://liderazgo.euroresidentes.com"
 }
 
-@misc{ wiki:conversion,
-	author = "Wikipedia",
-	title = "Conversión (informática) --- Wikipedia{,} La enciclopedia libre",
-	year = "2014",
-	url = "http://es.wikipedia.org/w/index.php?title=Conversi%C3%B3n_(inform%C3%A1tica)&oldid=72396537",
-	note = "[Internet; descargado 25-mayo-2015]"
+@misc{
+    wiki:liderazgo,
+    author = "Wikipedia",
+    title = "Liderazgo",
+    year = "2015",
+    url = "http://es.wikipedia.org/wiki/Liderazgo"
+}
+@misc{
+    wiki:guia_usuario,
+    author = "Wikipedia",
+    title = "Guía del usuario --- Wikipedia{,} La enciclopedia libre",
+    year = "2015",
+    url = "http://es.wikipedia.org/w/index.php?title=Gu%C3%ADa_del_usuario&oldid=79381229",
+    note = "[Internet; descargado 27-mayo-2015]"
 }
 
-@misc{ kendall-analisis-disenio-sistemas,
-	author = "Kendall \& Kendall",
-	title = "Análisis y diseño de sistemas",
-	year = "2005"
+@misc{
+    wiki:conversion,
+    author = "Wikipedia",
+    title = "Conversión (informática) --- Wikipedia{,} La enciclopedia libre",
+    year = "2014",
+    url = "http://es.wikipedia.org/w/index.php?title=Conversi%C3%B3n_(inform%C3%A1tica)&oldid=72396537",
+    note = "[Internet; descargado 25-mayo-2015]"
 }
 
-@misc{ punto2:relaciones-humanas,
-	author = " Lic. Alma Rosa Candela",
-	title = "Relaciones humanas en línea",
-	year = "2008",
-	url = " http://candelaramirezalmarosa.blogspot.com.ar/2008/02/114las-necesidades-humanas-como.html"
+@book{
+    kendall-analisis-disenio-sistemas,
+    title="Análisis y diseño de sistemas",
+    author="Kendall, K.E. and Kendall, J.E. and Ramos, A.N.",
+    isbn="9789702605775",
+    url="https://books.google.com.ar/books?id=5-rZA0FggusC",
+    year="2005",
+    publisher="Pearson Educación"
 }
 
-@misc{ punto2:motivacion-empresa,
-	title = "Motivación en la empresa",
-	url = "http://motivacionempresa.galeon.com/productos2280387.html"
+@misc{
+    punto2:relaciones-humanas,
+    author = "Candela, Alma Rosa",
+    title = "Relaciones humanas en línea",
+    year = "2008",
+    url = " http://candelaramirezalmarosa.blogspot.com.ar/2008/02/114las-necesidades-humanas-como.html"
 }
 
-@misc{ punto2:motivacion,
-	author = "Rosa M. Mora",
-	title = "Motivación",
-	url = "http://morasolano.tripod.com/id13.html"
+@misc{
+    punto2:motivacion-empresa,
+    author = "{Motivación en la empresa}",
+    title = "Tipos de motivación",
+    year = "2015",
+    url = "http://motivacionempresa.galeon.com/productos2280387.html"
 }
 
-@misc{ punto2:senn-analisis-disenio,
-	author = "James Senn",
-	title = "Análisis y diseño de sistemas de información",
-	year = "2006"
+@misc{
+    punto2:motivacion,
+    author = "Mora, Rosa M.",
+    title = "Motivación",
+    year = "2012",
+    url = "http://morasolano.tripod.com/id13.html"
 }
 
-@misc{ punto2:vender-software,
-	author = "Velneo",
-	title = "¿Cómo vender programas de software?",
-	year = "2015",
-	url = "http://velneo.es/como-vender-programas-de-software/"
-}
-%Trabajo práctico integrador nº2
-@misc{ wiki:xxx,
-	author = "Wikipedia",
-	title = "Front-end y back-end --- Wikipedia{,} La enciclopedia libre",
-	year = "2015",
-	url = "http://es.wikipedia.org/w/index.php?title=Front-end_y_back-end&oldid=82186853",
-	note = "[Internet; descargado 2-junio-2015]"
+@book{
+    senn1992analisis,
+    title="Análisis y diseño de sistemas de información",
+    author="Senn, J.A.",
+    isbn="9789684229914",
+    series="McGraw-Hill sobre Sistemas de Información",
+    url="https://books.google.com.ar/books?id=ZIuZQgAACAAJ",
+    year="2006",
+    publisher="McGraw-Hill"
 }
 
-@misc{ ang:xxx,
-	author = "Angular",
-	title = "AngularJS ",
-	url = "https://angularjs.org/"
-	
+@misc{
+    punto2:vender-software,
+    author = "Velneo",
+    title = "¿Cómo vender programas de software?",
+    year = "2015",
+    url = "http://velneo.es/como-vender-programas-de-software/"
 }
 
-@misc{ wiki:xxx,
-	author = "Wikipedia",
-	title = "DevOps --- Wikipedia{,} La enciclopedia libre",
-	year = "2015",
-	url = "http://es.wikipedia.org/w/index.php?title=DevOps&oldid=82549358",
-	note = "[Internet; descargado 2-junio-2015]"
+% Trabajo práctico 2 - Parte 3
+
+@misc{
+    wiki:mega,
+    author = "Wikipedia",
+    title = "Mega (service) --- Wikipedia{,} The Free Encyclopedia",
+    year = "2015",
+    url = "https://en.wikipedia.org/w/index.php?title=Mega_(service)&oldid=666696170",
+    note = "[Online; accessed 14-June-2015]"
+}
+ 
+@misc{
+    wiki:factibilidad,
+    author = "Wikipedia",
+    title = "Factibilidad --- Wikipedia{,} La enciclopedia libre",
+    year = "2015",
+    url = "http://es.wikipedia.org/w/index.php?title=Factibilidad&oldid=83119094",
+    note = "[Internet; descargado 12-junio-2015]"
 }
 
-@misc{ wiki:xxx,
-	author = "Wikipedia",
-	title = "Shippable --- Wikipedia{,} The Free Encyclopedia",
-	year = "2014",
-	url = "http://en.wikipedia.org/w/index.php?title=Shippable&oldid=637226960",
-	note = "[Online; accessed 2-June-2015]"
+@misc{
+    wiki:phr,
+    author = "Wikipedia",
+    title = "Personal health record --- Wikipedia{,} The Free Encyclopedia",
+    year = "2015",
+    url = "https://en.wikipedia.org/w/index.php?title=Personal_health_record&oldid=659368699",
+    note = "[Online; accessed 16-June-2015]"
 }
 
-@misc{kar:xxx, 
-	author = "Karma",
-	title = "Karma ",
-	url = "http://karma-runner.github.io/0.12/index.html"
-	
+@misc{
+    gestiopolis:estudio-integral-factibilidad,
+    author = "Duffus, Miranda Dayana",
+    title = "Estudio integral de factibilidad de proyectos de inversión",
+    year = "2007",
+    url = "http://www.gestiopolis.com/estudio-integral-de-factibilidad-de-proyectos-de-inversion/"
 }
 
-@misc{jas:xxx, 
-	author = "Jasmin",
-	title = "Jasmin-Introduccion ",
-	url = "http://jasmine.github.io/edge/introduction.html"
-	
+@misc{
+    conv:constitucion-argentina-1994,
+    author = "{Convención Nacional Constituyente}",
+    title = "Constitución nacional de la República Argentina",
+    year = "1994",
+    url = "http://pdba.georgetown.edu/Constitutions/Argentina/argen94.html"
 }
 
-@misc{jav:xxx, 
-	author = "Javier Garzás",
-	title = "Sprint 0",
-	url = "http://www.javiergarzas.com/2013/07/el-sprint-cero-y-el-sprint-de-release.html"
-	
+@misc{
+    infoleg:ley-25326,
+    author = "InfoLEG",
+    title = "Ley 25.326: Ley de protección de los datos personales",
+    year = "2000",
+    url = "http://www.infoleg.gov.ar/infolegInternet/anexos/60000-64999/64790/texact.htm"
 }
 
+@misc{
+    infoleg:decreto-1558-2001,
+    author = "InfoLEG",
+    title = "Decreto 1558/2001: Actualización de la Ley 25.326",
+    year = "2001",
+    url = "http://infoleg.mecon.gov.ar/infolegInternet/anexos/70000-74999/70368/texact.htm"
+}
+
+@misc{
+    infoleg:ley-26742,
+    author = "InfoLEG",
+    title = "Ley 26.742",
+    year = "2012",
+    url = "http://www.infoleg.gov.ar/infolegInternet/anexos/195000-199999/197859/norma.htm"
+}
+
+@misc{
+    infoleg:ley-15465,
+    author = "InfoLEG",
+    title = "Ley 15.465",
+    year = "1960",
+    url = "http://infoleg.mecon.gov.ar/infolegInternet/anexos/195000-199999/195093/norma.htm"
+}
+
+@misc{
+    infoleg:ley-25506,
+    author = "InfoLEG",
+    title = "Ley 25.506: Ley de firma digital",
+    year = "2001",
+    url = "http://infoleg.mecon.gov.ar/infolegInternet/anexos/70000-74999/70749/norma.htm"
+}
+
+@misc{
+    pdp:registro-nacional-bases-datos,
+    author = "{PDP: Protección de datos personales}",
+    title = "Registro nacional de bases de datos",
+    year = "2015",
+    url = "http://www.jus.gob.ar/datos-personales/areas-de-la-pdp/registro.aspx"
+}
+
+@misc{
+    pdp:instructivos-registro-bases-datos,
+    author = "{PDP: Protección de datos personales}",
+    title = "Instructivo para el registro de bases de datos",
+    year = "2015",
+    url = "http://www.jus.gob.ar/datos-personales/areas-de-la-pdp/registro/instructivos.aspx"
+}
+
+@misc{
+    pdp:con-vos-en-la-web,
+    author = "{PDP: Protección de datos personales}",
+    title = "Con vos en la web",
+    year = "2015",
+    url = "http://www.convosenlaweb.gob.ar/"
+}
+
+@misc{
+    habeasdata:datos-salud-25326,
+    author = "Palazzi, Pablo",
+    title = "Los datos de salud en la ley 25.326 de Protección de Datos Personales",
+    year = "2006",
+    url = "http://www.habeasdata.org/wp/category/salud/"
+}
+
+@misc{
+    tribunalmadrid:recurso-casacion-riego-valledor,
+    author = "{Tribunal Supremo de Madrid}",
+    title = "Recurso de casación: José María del Riego Valledor",
+    year = "2015",
+    url = "http://www.poderjudicial.es/search/documento/TS/7332583/proteccion%20de%20datos%20de%20caracter%20personal/20150324"
+}
+
+@misc{
+    ucsf:barriers-adoption-phr,
+    author = "Sheehy, Jeff",
+    title = "Barriers to adoption of electronic personal health records outlined",
+    year = "2009",
+    url = "http://www.ucsf.edu/news/2009/03/4208/barriers-adoption-electronic-personal-health-records-outlined"
+}
+
+@misc{
+    nytimes:ftc-privacy-mobile,
+    author = "Wyatt, Edward",
+    title = "F.T.C. Suggests Privacy Guidelines for Mobile Apps",
+    year = "2013",
+    url = "http://www.nytimes.com/2013/02/02/technology/ftc-suggests-do-not-track-feature-for-mobile-software-and-apps.html"
+}
+
+@misc{
+    opensource:licences-by-name,
+    author = "{Open Source Initiative}",
+    title = "Licences by Name",
+    year = "2015",
+    url = "http://opensource.org/licenses/alphabetical"
+}
+
+@misc{
+    wiki:gnu,
+    author = "Wikipedia",
+    title = "GNU General Public License --- Wikipedia{,} La enciclopedia libre",
+    year = "2015",
+    url = "http://es.wikipedia.org/w/index.php?title=GNU_General_Public_License&oldid=82980498",
+    note = "[Internet; descargado 16-junio-2015]"
+}
+
+@misc{
+    inpi:marcas-aranceles,
+    author = "{INPI: Instituto Nacional de la Propiedad Intelectual}",
+    title = "Dirección Nacional de Marcas: Aranceles",
+    year = "2015",
+    url = "http://www.inpi.gov.ar/index.php?Id=137&criterio=3"
+}
+
+@misc{
+    ompi:clasificacion-niza,
+    author = "{OMPI: Organización Mundial de la Propiedad Intelectual}",
+    title = "Clasificación de Niza",
+    year = "2015",
+    url = "http://www.wipo.int/classifications/nice/es/ITsupport/Version20150101/"
+}
+
+@misc{
+    nic:normativa-vigente-nic-ar,
+    author = "{NIC Argentina}",
+    title = "Normativa vigente",
+    year = "2015",
+    url = "https://nic.ar/normativa-vigente.xhtml"
+}
+
+@book{fernández1997guía,
+  title = "Guía metodológica para la evaluación del impacto ambiental",
+  author = "Fernández-Vítora, V.C. and Ripoll, V.C. and Ripoll, L.A.C. and Garro, V.R.",
+  isbn = "9788471146472",
+  url = "https://books.google.com/books?id=pV0VKP6999YC",
+  year = "1997",
+  publisher = "Mundi-Prensa"
+}
+
+@misc{
+    cricyt:contaminacion-automoviles-cricyt,
+    author = "CRICYT",
+    title = "Contaminación por automóviles",
+    year = "2015",
+    url = "http://www.cricyt.edu.ar/enciclopedia/terminos/ContamAut.htm"
+}

--- a/practicos/Diseño_Desarrollo_e_Implementación/main.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/main.tex
@@ -6,8 +6,8 @@
 % Bibliografía
 \usepackage[
 backend=biber,
-style=alphabetic,
-sorting=ynt
+style=authortitle,
+sorting=nty
 ]{biblatex}
 \bibliography{biblio}
 


### PR DESCRIPTION
Se integró la bibliografía del **TP2 - Parte 3 - Factibilidad**, y se corrigió la bibliografía ya existente. Además, se configuró que se **ordene en forma alfabética**, primero por el apellido y nombre del autor, y luego por el título de la referencia. También se cambió el estilo, para que se visualice con el estilo ```authortitle``` **[1]**, y así eliminar las referencias encerradas entre corchetes en la parte izquierda de la lista de referencias, que no se utilizan.

**[1]** [Biblatex bibliography styles - ShareLaTeX](https://es.sharelatex.com/learn/Biblatex_bibliography_styles)