### PR TITLE
Corrección de URLs que no respetan márgenes

### DIFF
--- a/practicos/Diseño_Desarrollo_e_Implementación/main.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/main.tex
@@ -65,9 +65,11 @@ sorting=nty
 
 
 \newpage
+\begin{sloppypar}
 \nocite{*}
 \printbibliography[
 heading=bibintoc
 ]
+\end{sloppypar}
 
 \end{document}

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/implementacion.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/implementacion.tex
@@ -44,8 +44,10 @@ Esta topología será mejor a la hora de escalar para soportar y brindar servici
 
 
 \subsubsection{Obtener DNS}
-Registrar un dominio que represente a \textbf{``YesDoc''}, el cuál será utilizado entre otras cosas como url del Web Service.
-Actualmente la web se encuentra hosteada en un subdominio de herokuapp. \textbf{``https://yesdoc.herokuapp.com''}
+\begin{sloppypar}
+Registrar un dominio que represente a \textbf{``YesDoc''}, el cual será utilizado, entre otros, como URL de la aplicación Web.
+Actualmente, el frontend web de \textit{YesDoc} se encuentra desplegado y funcionando en un subdominio de \textbf{HerokuApp}: \url{https://yesdoc.herokuapp.com}.
+\end{sloppypar}
 
 \subsubsection{Evaluar los costos y capacidades de servidores}
 Se evaluaran los costos necesarios en cuanto a servidores para poder  cumplir con los requerimientos de una cantidad inicial de usuarios. Luego será incrementada la capacidad de los cosmos a medida que la cantidad de usuarios aumente. 

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/manual_usuario.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/manual_usuario.tex
@@ -12,7 +12,9 @@
 \clearpage
 
 \subsection{Iniciar sesión}
-Para iniciar sesión en \textbf{\textit{YesDoc}}, debe ingresar al sitio web yesdoc \textit{http://yesdoc.herokuapp.com/}, cargar los datos que solicita el formulario de inicio de sesión y presionar en ingresar \textbf{[Figura \ref{mu-iniciar_sesion}]}.
+\begin{sloppypar}
+Para iniciar sesión en \textbf{\textit{YesDoc}}, debe ingresar al sitio web \url{https://yesdoc.herokuapp.com/}, cargar los datos que solicita el formulario de inicio de sesión y presionar en \textit{Ingresar} \textbf{[Figura \ref{mu-iniciar_sesion}]}.
+\end{sloppypar}
  \begin{figure}
  	\centering
  	\includegraphics[width=.8\textwidth]{img/manual_de_usuario/iniciar_sesion}

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/programacion_documentacion.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/programacion_documentacion.tex
@@ -204,8 +204,10 @@ api.add_resource(MeasurementUnitList, '/measurement_units')
 api.add_resource(PermissionTypeList, '/permission_types')
 \end{lstlisting}
 
+\begin{sloppypar}
 Cabe destacar que las rutas expuestas presentan un resumen y no la totalidad de rutas que presenta actualmente la API.
-Como podemos observar, el cliente tendrá acceso a la representación de respuesta del recurso MeasurementList solo enviando una representación correcta en una solicitud a la url http://dominio\_raiz/measurements.
+Como podemos observar, el cliente tendrá acceso a la representación de respuesta del recurso MeasurementList solo enviando una representación correcta en una solicitud a la URL \url{http://dominio_raiz/measurements}.
+\end{sloppypar}
 
 Por último, el tercer punto, se ubica en otro archivo y nos permite iniciar la API.
 
@@ -244,7 +246,8 @@ class MeasurementList(Resource):
         return new_measurement, 201
 \end{lstlisting}
 
-Como vemos el recurso define dos métodos, uno con el nombre get y otro con el nombre post, estos métodos responden a las solicitudes HTTP al identificador /measurements, que indiquen en el atributo method el operador GET y POST respectivamente. En el caso del recurso indicado, la solicitud con operando GET devolverá al cliente una colección de representaciones de medidas en la base de datos mientras que con el operando POST cargará una nueva medida.
+Como vemos el recurso define dos métodos, uno con el nombre \texttt{get} y otro con el nombre \texttt{post}.
+Estos métodos responden a las solicitudes HTTP al identificador \texttt{/measurements}, que indiquen en el atributo method el operador GET y POST respectivamente. En el caso del recurso indicado, la solicitud con operando GET devolverá al cliente una colección de representaciones de medidas en la base de datos mientras que con el operando POST cargará una nueva medida.
 
 La clase del modelo que para las medidas se encuentra en el paquete models del paquete mod\_profiles
 


### PR DESCRIPTION
Se hace uso del entorno ```sloppypar``` en aquellos lugares donde se nombran URLs, para que éstas no excedan el límite del margen derecho. **[1]**

**[1]** https://tex.stackexchange.com/questions/54946/how-to-break-long-url-in-an-item