### PR TITLE
Corrección en fechas planificadas de los sprints

### DIFF
--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_1.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_1.tex
@@ -1,8 +1,10 @@
 \section{Sprint 1: Generar perfil de datos personales}
-\subsection{Planificación}
-Inicio: Martes 28 de abril del 2015.
 
-Fin: Martes 19 de mayo del 2015.
+\subsection{Planificación}
+\begin{itemize}
+    \item \textbf{Inicio}: 28 de abril del 2015.
+    \item \textbf{Fin}: 19 de mayo del 2015.
+\end{itemize}
 
 \subsection{Descripción}
 En este sprint se realizará la sección del perfíl del usuario, para lo cual se deberá definir en el backend, las clases Profile y Gender, así como los recursos para acceder a ellas a través de la API. Además se realizara la documentación correspondiente para su consumo.

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_2.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_2.tex
@@ -1,9 +1,9 @@
 \section{Sprint 2} %CREAR, EDITAR Y MOSTRAR MEDICIONES
-\subsection{Planificación}
 
+\subsection{Planificación}
 \begin{itemize}
-    \item \textbf{Inicio}: Martes 19 de mayo del 2015
-    \item \textbf{Fin}: Martes 1 de julio del 2015 
+    \item \textbf{Inicio}: 19 de mayo del 2015.
+    \item \textbf{Fin}: 1 de julio del 2015.
 \end{itemize}
 
 \begin{figure}[h]

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_3.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_3.tex
@@ -1,9 +1,10 @@
 \section{Sprint 3}%Corrección de issues 
+
 \subsection{Planificación}
-
-\textbf{Inicio: }Martes 7 de julio del 2015 
-
-\textbf{Fin:} Martes 16 de Agosto del 2015
+\begin{itemize}
+    \item \textbf{Inicio}: 7 de julio del 2015.
+    \item \textbf{Fin}: 16 de agosto del 2015.
+\end{itemize}
 
 \begin{figure}[h!]
   \centering

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_4.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_4.tex
@@ -1,9 +1,10 @@
 \section{Sprint 4}%mostrar gráficas -validaciones
+
 \subsection{Planificación}
-
-\textbf{Inicio: }Martes 17 de julio del 2015 
-
-\textbf{Fin:} Martes 11 de Septiembre del 2015
+\begin{itemize}
+    \item \textbf{Inicio}: 17 de agosto del 2015.
+    \item \textbf{Fin}: 11 de septiembre del 2015.
+\end{itemize}
 
 \begin{figure}[h!]
   \centering

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_5.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_5.tex
@@ -1,10 +1,10 @@
 \section{Sprint 5}%Autenticación
+
 \subsection{Planificación}
-
-	\textbf{Inicio: } 10 de Septiembre del 2015
-	
-	\textbf{Fin:} 27 de Septiembre del 2015 
-
+\begin{itemize}
+    \item \textbf{Inicio}: 11 de septiembre del 2015.
+    \item \textbf{Fin}: 27 de septiembre del 2015.
+\end{itemize}
 
 
 \subsection{Descripción}

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_6.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_6.tex
@@ -1,9 +1,10 @@
 \section{Sprint 6} % MOSTRAR, CARGAR Y EDITAR ANÁLISIS
+
 \subsection{Planificación}
-
-\textbf{Inicio:  } 27 de septiembre del 2015
-
-\textbf{Fin: } 17 de octubre del 2015
+\begin{itemize}
+    \item \textbf{Inicio}: 27 de septiembre del 2015.
+    \item \textbf{Fin}: 17 de octubre del 2015.
+\end{itemize}
 
 \begin{figure}[h!]
   \centering

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_7.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_7.tex
@@ -1,12 +1,10 @@
 \section{Sprint 7} % DROPBOX
 
 \subsection{Planificación}
-
-
-\textbf{Inicio:} Martes 1 de octubre del 2015
-
-\textbf{Inicio:} Martes 17 de octubre del 2015
-
+\begin{itemize}
+    \item \textbf{Inicio}: 1 de octubre del 2015.
+    \item \textbf{Fin}: 17 de octubre del 2015.
+\end{itemize}
 
 
 \subsection{Descripción}

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_8.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_8.tex
@@ -1,11 +1,10 @@
 \section{Sprint 8} % COMENTARIO
 
 \subsection{Planificación}
-
-\textbf{Inicio: }?? del 2015 
-
-\textbf{Fin:} ?? de octubre del 2015
-
+\begin{itemize}
+    \item \textbf{Inicio}: ?? de ?? del 2015.
+    \item \textbf{Fin}: ?? de ?? del 2015.
+\end{itemize}
 
 
 \subsection{Descripción}

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_9.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/sprint_9.tex
@@ -1,11 +1,10 @@
 \section{Sprint 9} % COMPARTICIÓN
 
 \subsection{Planificación}
-
-\textbf{Inicio: }?? del 2015 
-
-\textbf{Fin:} ?? de octubre del 2015
-
+\begin{itemize}
+    \item \textbf{Inicio}: ?? de ?? del 2015.
+    \item \textbf{Fin}: ?? de ?? del 2015.
+\end{itemize}
 
 
 \subsection{Descripción}


### PR DESCRIPTION
Se corrigen las **fechas de planificación** de los sprints, dándole un formato común, y eliminando el nombre del día especificado.