### PR TITLE
Corrección 4: Añadir  "manual de usuario" luego de "Retroalimentación de pruebas"

### DIFF
--- a/practicos/Diseño_Desarrollo_e_Implementación/main.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/main.tex
@@ -43,6 +43,7 @@ sorting=nty
 \include{tex/programacion_documentacion}
 \include{tex/capacitacion}
 \include{tex/retroalimentacion_de_pruebas}
+\include{tex/manual_de_usuario}
 \include{tex/implementacion}
 \include{tex/tp2_cap1_cap2}
 \include{tex/tp2_capitulo3}

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/manual_de_usuario.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/manual_de_usuario.tex
@@ -1,0 +1,2 @@
+\subsection{Manual de Usuario}
+El manual de usuario del sistema se encuentra en el \textbf{[Apéndice \ref{manual_usuario}] ``Manual de usuario del sistema completo''}

--- a/practicos/Diseño_Desarrollo_e_Implementación/tex/tarifas-bases-de-datos.tex
+++ b/practicos/Diseño_Desarrollo_e_Implementación/tex/tarifas-bases-de-datos.tex
@@ -7,6 +7,6 @@
 \label{anexo:calendario-fonsoft}
      \begin{sidewaysfigure}[h]
          \centering
-\includegraphics[width=0.8\textwidth]{img/tp2_capitulo3/calendario-fonsoft}
+\includegraphics[width=1\textwidth]{img/tp2_capitulo3/calendario-fonsoft}
      \end{sidewaysfigure}
 


### PR DESCRIPTION
En esta sección se indica en que apéndice se encuentra el manual de usuario.

**ESTE PR DEBE SER ACEPTADO LUEGO DE ACEPTAR EL PR  "#92 - CORRECCION 3" ya que es parte de desarrollo e implementación y por ese motivo el título lleva "\subsection"**